### PR TITLE
Allow showWebView to be awaited

### DIFF
--- a/lib/src/internal/tabby_web_view.dart
+++ b/lib/src/internal/tabby_web_view.dart
@@ -20,12 +20,12 @@ class TabbyWebView extends StatefulWidget {
   @override
   State<TabbyWebView> createState() => _TabbyWebViewState();
 
-  static void showWebView({
+  static Future<void> showWebView({
     required BuildContext context,
     required String webUrl,
     required TabbyCheckoutCompletion onResult,
-  }) {
-    showModalBottomSheet(
+  }) async {
+    await showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       enableDrag: false,


### PR DESCRIPTION
This PR introduces a slight non-breaking change to the ```TabbyWebView.showWebView``` procedure. Allowing users to await the webview modal in addition to the the ```onResult``` callback.

It should not introduce any breaking changes.