### PR TITLE
Add awaitable TabbyWebView.showWebViewAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+- 🆕 New `TabbyWebView.showWebViewAsync(...)` — an awaitable way to open checkout: the SDK closes the sheet on the first result and the future resolves with `WebViewResult?` (`null` if the sheet was dismissed before checkout finished). No changes to the existing `showWebView` — current integrations keep working as is.
+
 # 2.0.0
 - ❗ Breaking change: `TabbySDK().setup(...)` is now `Future<void>` and must be awaited. Partners must update their integration (this is really an easy todo).
 - 🆕 SDK now bootstraps sharded base URLs from `POST /api/v1/sdk/config` during `setup()`. Per-request hosts are resolved by `Currency` (e.g. `Currency.sar` is routed to KSA-resident endpoints) with a `default` fallback.

--- a/README.md
+++ b/README.md
@@ -155,10 +155,49 @@ For any clarification, please refer to the [permission_handler](https://pub.dev/
       onResult: (WebViewResult resultCode) {
         print(resultCode.name);
         // TODO: Process resultCode
+        // The sheet stays open until you close it yourself,
+        // e.g. Navigator.pop(context);
       },
     );
   }
 ```
+
+If you prefer to `await` the checkout outcome instead of handling callbacks, use `showWebViewAsync`:
+
+```dart
+  Future<void> openInAppBrowser() async {
+    final resultCode = await TabbyWebView.showWebViewAsync(
+      context: context,
+      webUrl: session.availableProducts.installments.webUrl,
+    );
+    // The SDK closes the sheet automatically once the first result arrives.
+    switch (resultCode) {
+      case WebViewResult.authorized:
+        // Payment authorized — navigate to your order completion screen
+        break;
+      case WebViewResult.rejected:
+      case WebViewResult.expired:
+      case WebViewResult.close:
+        // Handle unsuccessful outcomes
+        break;
+      case null:
+        // The sheet was dismissed before checkout produced a result
+        break;
+    }
+  }
+```
+
+#### `showWebView` vs `showWebViewAsync` — which one to pick?
+
+| | `showWebView` | `showWebViewAsync` |
+|---|---|---|
+| Result delivery | `onResult` callback, fired for every checkout event | Returned `Future<WebViewResult?>` (first result wins); optional `onResult` is also called |
+| Sheet lifecycle | You close the sheet yourself (e.g. `Navigator.pop` inside `onResult`) | SDK closes the sheet automatically on the first result |
+| Dismissed without a result | `onResult` is simply never called | Future resolves with `null` |
+
+Use `showWebViewAsync` for the common "open checkout, wait for the outcome, continue" flow. Use `showWebView` when you need full control over the sheet lifecycle — for example, to keep the sheet open and recover in place when a session expires.
+
+Do not `await` `showWebView` — it returns `void` by design; the awaitable variant is `showWebViewAsync`.
 
 Also you can use TabbyWebView as inline widget on your page:
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -512,7 +512,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.1.0"
   term_glyph:
     dependency: transitive
     description:

--- a/lib/src/internal/tabby_web_view.dart
+++ b/lib/src/internal/tabby_web_view.dart
@@ -20,12 +20,75 @@ class TabbyWebView extends StatefulWidget {
   @override
   State<TabbyWebView> createState() => _TabbyWebViewState();
 
+  /// Opens Tabby checkout in a modal bottom sheet (callback-style).
+  ///
+  /// Every checkout event is delivered to [onResult]. The SDK does not close
+  /// the sheet — you decide when to dismiss it (typically by calling
+  /// `Navigator.pop(context)` inside [onResult]). Use this variant when you
+  /// want full control over the sheet lifecycle, e.g. to keep it open after
+  /// a `WebViewResult.expired` and load a fresh session.
+  ///
+  /// If you just want to wait for the checkout outcome, use
+  /// [showWebViewAsync] instead.
   static void showWebView({
     required BuildContext context,
     required String webUrl,
     required TabbyCheckoutCompletion onResult,
   }) {
-    showModalBottomSheet(
+    _showCheckoutSheet(
+      context: context,
+      builder: (context) {
+        return TabbyWebView(
+          webUrl: webUrl,
+          onResult: onResult,
+        );
+      },
+    );
+  }
+
+  /// Opens Tabby checkout in a modal bottom sheet and completes with the
+  /// checkout outcome (await-style).
+  ///
+  /// Unlike [showWebView], the SDK owns the sheet lifecycle: the sheet is
+  /// closed automatically as soon as the first checkout result arrives, and
+  /// the returned future resolves with that result. Resolves with `null`
+  /// when the sheet is dismissed before any result is received (e.g. the
+  /// user taps the barrier or navigates back).
+  ///
+  /// [onResult] is optional here and, when provided, is invoked with the
+  /// same result right before the sheet is closed.
+  static Future<WebViewResult?> showWebViewAsync({
+    required BuildContext context,
+    required String webUrl,
+    TabbyCheckoutCompletion? onResult,
+  }) async {
+    WebViewResult? result;
+    await _showCheckoutSheet(
+      context: context,
+      builder: (sheetContext) {
+        return TabbyWebView(
+          webUrl: webUrl,
+          onResult: (resultCode) {
+            // Only the first result counts: it closes the sheet, and any
+            // late-arriving bridge event must not pop the route below it.
+            if (result != null) {
+              return;
+            }
+            result = resultCode;
+            onResult?.call(resultCode);
+            Navigator.of(sheetContext).pop();
+          },
+        );
+      },
+    );
+    return result;
+  }
+
+  static Future<void> _showCheckoutSheet({
+    required BuildContext context,
+    required WidgetBuilder builder,
+  }) {
+    return showModalBottomSheet<void>(
       context: context,
       isScrollControlled: true,
       enableDrag: false,
@@ -36,12 +99,7 @@ class TabbyWebView extends StatefulWidget {
           top: Radius.zero,
         ),
       ),
-      builder: (context) {
-        return TabbyWebView(
-          webUrl: webUrl,
-          onResult: onResult,
-        );
-      },
+      builder: builder,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tabby_flutter_inapp_sdk
 description: Flutter SDK for Tabby Buy Now, Pay Later. A package that allows you to integrate Tabby payment methods into your Flutter app.
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/tabby-ai/tabby_flutter_inapp_sdk
 
 environment:


### PR DESCRIPTION
Alternative to callback-style showWebView for partners who want to await the checkout outcome: the SDK closes the sheet on the first result and the future resolves with WebViewResult? (null when the sheet is dismissed before checkout finishes). showWebView is unchanged.